### PR TITLE
CF related changes

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,11 @@
+---
+applications:
+- name: cf-nodejs
+  buildpack: nodejs_buildpack
+  stack: cflinuxfs3
+  memory: 512M
+  instances: 1
+  random-route: true
+  env:
+    DYNATRACE_BASEURL: https://yourtenant.live.dynatrace.com
+    DYNATRACE_APITOKEN: YourAPIToken

--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
     "body-parser": "^1.18.3",
     "dotenv": "^7.0.0",
     "express": "^4.16.4"
+  },
+  "engines": {
+    "node": "10.x",
+    "npm": "6.4.x"
   }
 }

--- a/server.js
+++ b/server.js
@@ -11,8 +11,9 @@ app.use(bodyParser.urlencoded({ extended: true })); // support encoded bodies
 app.use('/api', require('./routes/routes').router);
 
 // listen (start app with node server.js) 
-app.listen(8080, () => {
- console.log("Server running on port 8080");
+app.listen(process.env.PORT || 8080, () => {
+  console.log("Server running!");
 });
 
 module.exports = app;
+


### PR DESCRIPTION
Changes necessary to run on Cloud Foundry:

- Vendoring node.js in packages.json
- manifest file
- Making node use port defined in environment variable or a default of 8080
- 
